### PR TITLE
Bump playwright to 1.55.1 (high)

### DIFF
--- a/tests/site-compat/package.json
+++ b/tests/site-compat/package.json
@@ -9,6 +9,6 @@
     "suite": "node suite.mjs"
   },
   "devDependencies": {
-    "playwright": "^1.49.0"
+    "playwright": "^1.55.1"
   }
 }


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `playwright` `1.49.0` → `1.55.1`
**Manifest:** `tests/site-compat/package.json`
**Severity:** high
**Advisory:** Playwright downloads and installs browsers without verifying the authenticity of the SSL certificate CVE-2025-59288

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `4f58b4bfce7f82e7` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"4f58b4bfce7f82e7","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->