### PR TITLE
Prevent cp errors from masking bundle-bin failure

### DIFF
--- a/scripts/xcode-copy-binaries.sh
+++ b/scripts/xcode-copy-binaries.sh
@@ -9,6 +9,7 @@
 # runtime (MITM and local caching proxy are opt-in features).
 
 set -uo pipefail
+set -e
 
 SRC="${SRCROOT}/build/bundle-bin"
 DST="${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/bin"


### PR DESCRIPTION
### FabGPT — code quality

**File:** `scripts/xcode-copy-binaries.sh`

**Rationale:** The script currently exits with code 0 if the initial population of bundle-bin fails, but subsequent `cp` commands for mitmproxy.app or libraries will still execute. If those copies fail (e.g., due to missing source files or permission issues), the build phase incorrectly reports success (exit 0) while the bundle is incomplete, potentially causing runtime failures. Setting `set -e` ensures the script exits immediately on any copy failure, preventing the propagation of a broken bundle.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen/qwen3.5-9b` · task `62e00d582dd8fa2f` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"62e00d582dd8fa2f","source":"quality","model":"qwen/qwen3.5-9b","severity":"INFO","iterations":1,"inference_s":48.86,"prompt_sha":"1c3de06b74a0b712","triage":"INFO"} -->